### PR TITLE
Make Title and Subtitle Optional in UpWindowAngularComponent

### DIFF
--- a/projects/up-window-angular/src/lib/up-window-angular.component.html
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.html
@@ -23,15 +23,25 @@
         &times;
       </button>
     }
-    <div class="up-window-header">
-      <h3 id="dialog-title" class="up-window-title">{{ title }}</h3>
-      <h4 id="dialog-description" class="up-window-subtitle">
-        {{ subtitle }}
-      </h4>
-    </div>
+
+    @if(title || subtitle) {
+      <div class="up-window-header">
+        @if(title) {
+          <h3 id="dialog-title" class="up-window-title">{{ title }}</h3>
+        }
+
+        @if(subtitle) {
+          <h4 id="dialog-description" class="up-window-subtitle">
+            {{ subtitle }}
+          </h4>
+        }
+      </div>
+    }
+
     <div class="up-window-body">
       <ng-content></ng-content>
     </div>
+
     <div class="up-window-footer" [ngClass]="'align-' + buttonAlignment">
       <button
         class="btn btn-cancel"

--- a/projects/up-window-angular/src/lib/up-window-angular.component.scss
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.scss
@@ -50,6 +50,7 @@
 .up-window-header {
   display: flex;
   flex-direction: column;
+  margin-bottom: 20px;
 }
 
 .up-window-title,
@@ -67,7 +68,7 @@
 }
 
 .up-window-body {
-  margin: 20px 0;
+  margin: 0 0 20px;
 }
 
 .up-window-footer {

--- a/projects/up-window-angular/src/lib/up-window-angular.component.ts
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.ts
@@ -25,9 +25,8 @@ import {
   encapsulation: ViewEncapsulation.None,
 })
 export class UpWindowAngularComponent implements OnInit, OnDestroy {
-  @Input() title: string = 'Default Title';
-  @Input() subtitle: string = 'Default Subtitle';
-  @Input() size: string = 'medium';
+  @Input() title?: string;
+  @Input() subtitle?: string;
   @Input() class: string | undefined;
   @Input() isOpen: WritableSignal<boolean> = signal(false);
   @Input() animation: string = 'fade';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -155,8 +155,6 @@
         </button>
         <up-window-angular
           [isOpen]="isWindowOpenFullScreen"
-          title="FullScreen Window"
-          subtitle="This window mode FullScreen."
           [fullScreen]="true"
         >
           Mode FullScreen content!


### PR DESCRIPTION
This pull request modifies the `UpWindowAngularComponent` to make the `title` and `subtitle` inputs optional. This change enhances the flexibility of the component, allowing it to be used in scenarios where these elements may not be necessary.

#### Changes Made
- Updated the `@Input` properties for `title` and `subtitle` to allow `undefined` values, making them optional.
- Added conditional rendering for the `title` and `subtitle` in the template, ensuring that the corresponding HTML elements are only generated when values are provided.

#### Code Snippet

```typescript
// In up-window-angular.component.ts
@Input() title?: string; // Now optional
@Input() subtitle?: string; // Now optional
```

```html
@if(title || subtitle) {
    <div class="up-window-header">
      @if(title) {
        <h3 id="dialog-title" class="up-window-title">{{ title }}</h3>
      }

      @if(subtitle) {
        <h4 id="dialog-description" class="up-window-subtitle">
          {{ subtitle }}
        </h4>
      }
    </div>
  }
```

#### Testing
- Verified that the component functions correctly without a `title` or `subtitle`.
- Confirmed that existing functionality remains intact and unaffected by these changes.