### PR TITLE
Add Blur Effect Option to Modal Background

### DIFF
--- a/projects/up-window-angular/src/lib/up-window-angular.component.html
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.html
@@ -2,6 +2,7 @@
   #modal
   class="overlay"
   [class.active]="isOpen()"
+  [class.blur]="blur"
   role="dialog"
   aria-labelledby="dialog-title"
   aria-describedby="dialog-description"

--- a/projects/up-window-angular/src/lib/up-window-angular.component.scss
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.scss
@@ -17,6 +17,10 @@
     display: flex;
     opacity: 1;
   }
+
+  &.blur {
+    backdrop-filter: blur(6px);
+  }
 }
 
 .up-window {

--- a/projects/up-window-angular/src/lib/up-window-angular.component.spec.ts
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.spec.ts
@@ -167,4 +167,20 @@ describe('UpWindowAngularComponent', () => {
     const windowElement = fixture.debugElement.query(By.css('.up-window'));
     expect(windowElement.classes['fullscreen']).toBeFalsy();
   });
+
+  it('should apply blur class when blur input is true', () => {
+    component.blur = true;
+    fixture.detectChanges();
+
+    const overlayElement = fixture.debugElement.query(By.css('.overlay'));
+    expect(overlayElement.classes['blur']).toBeTrue();
+  });
+
+  it('should not apply blur class when blur input is false', () => {
+    component.blur = false;
+    fixture.detectChanges();
+
+    const overlayElement = fixture.debugElement.query(By.css('.overlay'));
+    expect(overlayElement.classes['blur']).toBeFalsy();
+  });
 });

--- a/projects/up-window-angular/src/lib/up-window-angular.component.ts
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.ts
@@ -32,6 +32,7 @@ export class UpWindowAngularComponent implements OnInit, OnDestroy {
   @Input() animation: string = 'fade';
   @Input() restrictMode: boolean = false;
   @Input() fullScreen: boolean = false;
+  @Input() blur: boolean = false;
   @Input() confirmText: string = 'Confirm';
   @Input() cancelText: string = 'Cancel';
   @Input() confirmType: string = 'primary';
@@ -147,6 +148,7 @@ export class UpWindowAngularComponent implements OnInit, OnDestroy {
       [`${this.animation}-out`]: this.closingAnimation,
       shake: this.shakeAnimation,
       fullscreen: this.fullScreen,
+      blur: this.blur,
     };
   }
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -159,6 +159,21 @@
         >
           Mode FullScreen content!
         </up-window-angular>
+        <button
+          class="button-modal-example"
+          type="button"
+          (click)="openWindowExample('blur')"
+        >
+        <span class="material-symbols-outlined"> deblur </span> Blur
+        </button>
+        <up-window-angular
+          [isOpen]="isWindowOpenBlur"
+          title="Blur Window"
+          subtitle="This window mode Blur."
+          [blur]="true"
+        >
+          Mode Blur content!
+        </up-window-angular>
       </div>
     </div>
   </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ export class AppComponent {
   isWindowOpenScale: WritableSignal<boolean> = signal(false);
   isWindowOpenRestrict: WritableSignal<boolean> = signal(false);
   isWindowOpenFullScreen: WritableSignal<boolean> = signal(false);
+  isWindowOpenBlur: WritableSignal<boolean> = signal(false);
 
   openWindowExample(type: string) {
     this.isWindowOpenFade.set(false);
@@ -46,6 +47,7 @@ export class AppComponent {
     this.isWindowOpenScale.set(false);
     this.isWindowOpenRestrict.set(false);
     this.isWindowOpenFullScreen.set(false);
+    this.isWindowOpenBlur.set(false);
 
     switch (type) {
       case 'fade':
@@ -71,6 +73,9 @@ export class AppComponent {
         break;
       case 'fullscreen':
         this.isWindowOpenFullScreen.set(true);
+        break;
+      case 'blur':
+        this.isWindowOpenBlur.set(true);
         break;
     }
   }


### PR DESCRIPTION
This pull request adds an optional blur effect to the modal background in the `UpWindowAngularComponent`. The blur effect is controlled via a new `@Input()` property `blur`, which, when set to `true`, applies a subtle background blur to the modal's overlay, enhancing the visual appearance.

#### Changes Implemented

1. **New Input Property**:
   - Added a new input property: `blur` (boolean), defaulting to `false`. This allows users of the modal component to enable or disable the blur effect on the background overlay.

2. **CSS Changes**:
   - The `overlay` class has been updated to include a `blur` modifier, which applies a `backdrop-filter: blur(6px)` effect when active.

3. **HTML Updates**:
   - The modal's `div` structure now includes a conditional `blur` class binding to control when the blur effect is applied.

4. **TypeScript Logic**:
   - The `getClass()` method now includes logic to conditionally add the `blur` class based on the `blur` input.

#### Testing
- Tested the blur effect on various screen sizes and browsers to ensure proper performance and rendering.
- Verified that the blur effect does not interfere with modal functionality such as focus trapping or keyboard navigation.
- Ensured the modal works as expected with or without the blur effect based on the input value.