### PR TITLE
Refactor Modal to Use `up-window-container`

### DIFF
--- a/projects/up-window-angular/src/lib/up-window-angular.component.html
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.html
@@ -1,15 +1,12 @@
 <div
   #modal
-  class="overlay"
+  class="up-window-container"
   [class.active]="isOpen()"
-  [class.blur]="blur"
-  [class.grayscale]="grayscale"
   role="dialog"
   aria-labelledby="dialog-title"
   aria-describedby="dialog-description"
   aria-modal="true"
   [attr.aria-hidden]="!isOpen()"
-  (click)="closeWindow('overlay')"
 >
   <div
     class="up-window"
@@ -17,27 +14,23 @@
     (click)="$event.stopPropagation()"
   >
     @if(!restrictMode || hiddenActions) {
-      <button
-        class="close-window"
-        aria-label="Close window"
-        (click)="closeWindow()"
-      >
-        &times;
-      </button>
-    }
-
-    @if(title || subtitle) {
-      <div class="up-window-header">
-        @if(title) {
-          <h3 id="dialog-title" class="up-window-title">{{ title }}</h3>
-        }
-
-        @if(subtitle) {
-          <h4 id="dialog-description" class="up-window-subtitle">
-            {{ subtitle }}
-          </h4>
-        }
-      </div>
+    <button
+      class="close-window"
+      aria-label="Close window"
+      (click)="closeWindow()"
+    >
+      &times;
+    </button>
+    } @if(title || subtitle) {
+    <div class="up-window-header">
+      @if(title) {
+      <h3 id="dialog-title" class="up-window-title">{{ title }}</h3>
+      } @if(subtitle) {
+      <h4 id="dialog-description" class="up-window-subtitle">
+        {{ subtitle }}
+      </h4>
+      }
+    </div>
     }
 
     <div class="up-window-body">
@@ -45,24 +38,33 @@
     </div>
 
     @if(!hiddenActions) {
-      <div class="up-window-footer" [ngClass]="'align-' + buttonAlignment">
-        <button
-          class="btn btn-cancel"
-          [ngClass]="getButtonClass(cancelType)"
-          (click)="onCancel()"
-          [attr.aria-label]="cancelText"
-        >
-          {{ cancelText }}
-        </button>
-        <button
-          class="btn btn-confirm"
-          [ngClass]="getButtonClass(confirmType)"
-          (click)="onConfirm()"
-          [attr.aria-label]="confirmText"
-        >
-          {{ confirmText }}
-        </button>
-      </div>
+    <div class="up-window-footer" [ngClass]="'align-' + buttonAlignment">
+      <button
+        class="btn btn-cancel"
+        [ngClass]="getButtonClass(cancelType)"
+        (click)="onCancel()"
+        [attr.aria-label]="cancelText"
+      >
+        {{ cancelText }}
+      </button>
+      <button
+        class="btn btn-confirm"
+        [ngClass]="getButtonClass(confirmType)"
+        (click)="onConfirm()"
+        [attr.aria-label]="confirmText"
+      >
+        {{ confirmText }}
+      </button>
+    </div>
     }
   </div>
+  <div
+    class="overlay"
+    (click)="closeWindow('overlay')"
+    [class.fade]="openingAnimation"
+    [class.fade-out]="closingAnimation"
+    [class.active]="isOpen()"
+    [class.blur]="blur"
+    [class.grayscale]="grayscale"
+  ></div>
 </div>

--- a/projects/up-window-angular/src/lib/up-window-angular.component.scss
+++ b/projects/up-window-angular/src/lib/up-window-angular.component.scss
@@ -1,21 +1,44 @@
+.up-window-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  opacity: 0;
+
+  &.active {
+    display: flex;
+    opacity: 1;
+  }
+}
+
 .overlay {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  transition: opacity 0.5s ease-in-out;
+  background-color: transparent;
+  display: flex;
   opacity: 0;
-  z-index: 999;
+  z-index: 1;
+  transition: all 0.5s;
 
   &.active {
-    display: flex;
     opacity: 1;
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+
+  &.fade {
+    animation: up-window-fadeIn 0.3s forwards;
+  }
+
+  &.fade-out {
+    animation: up-window-fadeOut 0.5s forwards;
   }
 
   &.blur {
@@ -40,6 +63,8 @@
   padding: 20px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   margin: 1rem;
+  z-index: 99;
+
   &.fullscreen {
     position: fixed;
     top: 0;


### PR DESCRIPTION
This PR refactors the modal structure by introducing a new `up-window-container` component. The overlay-related logic and class bindings are moved outside the modal content to improve separation of concerns.

**Changes:**
- Wrapped the modal inside a new `up-window-container`.
- Moved overlay class bindings (`blur`, `grayscale`, `active`, etc.) to `up-window-container`.
- Kept modal content (`up-window`) intact but cleaned up class and event handling.

**Benefits:**
- Improved code organization and readability.
- Clear distinction between overlay and modal content.
- Easier to manage animations and visual effects in the future.

**Testing:**
- Verified that the modal opens, closes, and behaves as expected.
- Confirmed the proper application of animations and visual effects.